### PR TITLE
Quiet Output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.12"
   - "0.10"

--- a/bin/docklint
+++ b/bin/docklint
@@ -4,12 +4,20 @@
 
 var fs = require('fs');
 var path = require('path');
+var program = require('commander');
+var version = require('../package.json').version;
 var validateDockerfile = require('../');
 
 var fileLocation, dockerfile;
 
-if (process.argv.length > 2) {
-  fileLocation = process.argv[process.argv.length - 1];
+program
+  .version(version)
+  .usage('[options] [file]')
+  .option('-q, --quiet', 'Silence non-fatal notifications')
+  .parse(process.argv);
+
+if (program.args.length) {
+  fileLocation = program.args.shift();
 } else {
   fileLocation = path.join(process.cwd(), 'Dockerfile');
 }
@@ -21,8 +29,7 @@ try {
   process.exit(1);
 }
 
-
-var validation = validateDockerfile(dockerfile);
+var validation = validateDockerfile(dockerfile, { quiet: program.quiet });
 
 if (validation.valid) {
   console.log('Dockerfile looks good!');

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function finish (errors) {
   };
 }
 
-function validate(dockerfile) {
+function validate(dockerfile, opts) {
+  opts = opts || {};
   if (typeof dockerfile !== 'string') {
     return finish([{
       message: 'Invalid type',
@@ -115,7 +116,7 @@ function validate(dockerfile) {
     var validParams = paramsRegexes[instruction].test(params)
       && (paramValidators[instruction] ? paramValidators[instruction](params) : true);
 
-    if (!validParams) {
+    if (!validParams && !opts.quiet) {
       errors.push({
         message: 'Bad parameters',
         line: currentLine,
@@ -139,7 +140,7 @@ function validate(dockerfile) {
     });
   }
 
-  if (!hasCmd) {
+  if (!hasCmd && !opts.quiet) {
     errors.push({
       message: 'Missing CMD',
       priority: 1

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "istanbul": "^0.3.4",
     "mocha": "^2.0.1",
     "should": "^6.0.3"
+  },
+  "dependencies": {
+    "commander": "^2.8.1"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -2,12 +2,12 @@
 
 require('should');
 
-var validateDockerfile = require('../')
-  , find = require('find')
-  , fs = require('fs')
-  , path = require('path')
-  , callbackCount = require('callback-count')
-  , EOL = require('os').EOL;
+var EOL = require('os').EOL;
+var callbackCount = require('callback-count');
+var find = require('find')
+var fs = require('fs');
+var path = require('path');
+var validateDockerfile = require('../');
 
 // dockerfiles tested here from https://github.com/kstaken/dockerfile-examples/tree/master/salt-minion
 describe('valid dockerfiles', function () {
@@ -26,6 +26,15 @@ describe('valid dockerfiles', function () {
         counter.next();
       });
     });
+  });
+
+  it('Should take a missing CMD w/ quiet enabled', function () {
+    var dockerfile = 'FROM Vader/Death-Star' + EOL;
+
+    var result = validateDockerfile(dockerfile, { quiet: true });
+
+    result.should.be.an.Object;
+    result.should.have.property('valid', true);
   });
 });
 


### PR DESCRIPTION
This introduces a `-q, --quiet` flag to the CLI (and options when using the module) to silence non-fatal errors. If the flag is used, non-fatal errors will not be printed and the cli will exit normally.

This is to address #14. Feedback welcome!