### PR TITLE
Allow one-lined envs

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var paramsRegexes = {
   from: /^[a-z0-9.\/_-]+(:[a-z0-9._-]+)?$/,
   maintainer: /.+/,
   expose: /^[0-9]+([0-9\s]+)?$/,
-  env: /^[a-zA-Z_]+[a-zA-Z0-9_]* .+$/,
+  env: /^(([a-zA-Z_]+[a-zA-Z0-9_]* \S+$)|(( )?[a-zA-Z_]+[a-zA-Z0-9_]*=\S+)+)$/,
   user: /^[a-z_][a-z0-9_]{0,30}$/,
   run: /.+/,
   cmd: /.+/,

--- a/test/Dockerfiles/Dockerfile-0
+++ b/test/Dockerfiles/Dockerfile-0
@@ -5,9 +5,8 @@ MAINTAINER Kimbro Staken version: 0.1
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV APACHE_RUN_USER www-data
-ENV APACHE_RUN_GROUP www-data
-ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_RUN_USER=www-data APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_RUN_GROUP=www-data
 
 EXPOSE 80
 


### PR DESCRIPTION
Allow envs to be like 'ENV env1=as env2=sda'
Add unit tests for new env